### PR TITLE
Fix --url command in help text

### DIFF
--- a/Commands/AddSite.php
+++ b/Commands/AddSite.php
@@ -24,7 +24,7 @@ class AddSite extends ConsoleCommand
         $HelpText = 'The <info>%command.name%</info> command will add new site.
 <comment>Samples:</comment>
 To run:
-<info>%command.name% --name=Foo --url=https://foo.bar</info>
+<info>%command.name% --name=Foo --urls=https://foo.bar</info>
 You could use options to override config or environment variables:
 <info>%command.name% --db-backup-path=/tmp/foo</info>';
         $this->setHelp($HelpText);


### PR DESCRIPTION
This is a minor help text bug fix for the the `site:add` command.