### PR TITLE
Add --port argument to the extratools plugin

### DIFF
--- a/Commands/BackupDb.php
+++ b/Commands/BackupDb.php
@@ -87,6 +87,7 @@ You could use options to override config or environment variables:
 
         $config = [
             'db_host' =>  $db_configs['host'],
+            'db_port' =>  $db_configs['port'],
             'db_user' => $db_configs['username'],
             'db_pass' => $db_configs['password'],
             'db_name' =>  $db_configs['dbname'],

--- a/Commands/CreateDb.php
+++ b/Commands/CreateDb.php
@@ -74,6 +74,7 @@ To run:
         if ($force === true) {
             $config = [
                 'db_host' => $db_configs['host'],
+                'db_port' => $db_configs['port'],
                 'db_user' => $db_configs['username'],
                 'db_pass' => $db_configs['password'],
                 'db_name' => $db_configs['dbname'],

--- a/Commands/DropDb.php
+++ b/Commands/DropDb.php
@@ -66,6 +66,7 @@ To run:
 
         $config = [
             'db_host' =>  $db_configs['host'],
+            'db_port' =>  $db_configs['port'],
             'db_user' => $db_configs['username'],
             'db_pass' => $db_configs['password'],
             'db_name' =>  $db_configs['dbname'],

--- a/Commands/ImportDb.php
+++ b/Commands/ImportDb.php
@@ -76,6 +76,7 @@ To run:
 
         $config = [
             'db_host' =>  $db_configs['host'],
+            'db_port' =>  $db_configs['port'],
             'db_user' => $db_configs['username'],
             'db_pass' => $db_configs['password'],
             'db_name' =>  $db_configs['dbname'],

--- a/Commands/InstallMatomo.php
+++ b/Commands/InstallMatomo.php
@@ -112,6 +112,13 @@ Example:
             $this->defaults()->dbHost()
         );
         $this->addOption(
+            'db-port',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'DB port',
+            $this->defaults()->dbPort()
+        );
+        $this->addOption(
             'db-name',
             null,
             InputOption::VALUE_OPTIONAL,
@@ -174,6 +181,7 @@ Example:
         $db_username = $input->getOption('db-username');
         $db_pass = $input->getOption('db-pass');
         $db_host = $input->getOption('db-host');
+        $db_port = $input->getOption('db-port');
         $db_name = $input->getOption('db-name');
         $db_prefix = $input->getOption('db-prefix');
         $db_adapter = $input->getOption('db-adapter');
@@ -201,6 +209,7 @@ Example:
             'db-username' => $db_username,
             'db-pass' =>  $db_pass,
             'db-host' => $db_host,
+            'db-port' => $db_port,
             'db-name' => $db_name,
             'db-prefix' => $db_prefix,
             'db-adapter' => $db_adapter,
@@ -211,6 +220,7 @@ Example:
 
         $config = [
             'db_host' => $db_host,
+            'db_port' => $db_port,
             'db_user' => $db_username,
             'db_pass' => $db_pass,
             'db_name' => $db_name,

--- a/Lib/Backup.php
+++ b/Lib/Backup.php
@@ -27,6 +27,7 @@ class Backup
         // Fetch config.
         $backup_folder = $this->config['db_backup_folder'];
         $db_host = $this->config['db_host'];
+        $db_port = $this->config['db_port'];
         $db_user = $this->config['db_user'];
         $db_pass = $this->config['db_pass'];
         $db_name = $this->config['db_name'];
@@ -34,7 +35,7 @@ class Backup
 
         $timestamp = date("Ymd-His");
         $backup = new Process\Process(
-            "mysqldump -u $db_user -h $db_host -p$db_pass $db_name --add-drop-table >" .
+            "mysqldump -u $db_user -h $db_host -P $db_port -p$db_pass $db_name --add-drop-table >" .
             "$backup_folder/$prefix-$timestamp.sql" . " 2> >(grep -v \"Using a password\")"
         );
         $backup->enableOutput();

--- a/Lib/Create.php
+++ b/Lib/Create.php
@@ -25,12 +25,13 @@ class Create
     public function execute()
     {
         $db_host = $this->config['db_host'];
+        $db_port = $this->config['db_port'];
         $db_user = $this->config['db_user'];
         $db_pass = $this->config['db_pass'];
         $db_name = $this->config['db_name'];
 
         $drop = new Process\Process(
-            "mysqladmin -u $db_user -h $db_host -p$db_pass create $db_name --force"
+            "mysqladmin -u $db_user -h $db_host -P $db_port -p$db_pass create $db_name --force"
         );
         $drop->enableOutput();
         $drop->run();

--- a/Lib/Defaults.php
+++ b/Lib/Defaults.php
@@ -26,6 +26,21 @@ class Defaults
     /**
      * @return string
      */
+    public function dbPort()
+    {
+        $port = '';
+        if (getenv('MATOMO_DATABASE_PORT')) {
+            $port = getenv('MATOMO_DATABASE_PORT');
+        }
+        if (getenv('MATOMO_DB_PORT')) {
+            $port = getenv('MATOMO_DB_PORT');
+        }
+        return $port;
+    }
+
+    /**
+     * @return string
+     */
     public function dbName()
     {
         $name = '';

--- a/Lib/Drop.php
+++ b/Lib/Drop.php
@@ -25,12 +25,13 @@ class Drop
     public function execute()
     {
         $db_host = $this->config['db_host'];
+        $db_port = $this->config['db_port'];
         $db_user = $this->config['db_user'];
         $db_pass = $this->config['db_pass'];
         $db_name = $this->config['db_name'];
 
         $drop = new Process\Process(
-            "mysqladmin -u $db_user -h $db_host -p$db_pass drop $db_name --force"
+            "mysqladmin -u $db_user -h $db_host -P $db_port -p$db_pass drop $db_name --force"
         );
         $drop->enableOutput();
         $drop->run();

--- a/Lib/Import.php
+++ b/Lib/Import.php
@@ -27,12 +27,13 @@ class Import
         // Fetch config.
         $backup_path = $this->config['db_backup_path'];
         $db_host = $this->config['db_host'];
+        $db_port = $this->config['db_port'];
         $db_user = $this->config['db_user'];
         $db_pass = $this->config['db_pass'];
         $db_name = $this->config['db_name'];
 
         $import = new Process\Process(
-            "mysql -u $db_user -h $db_host -p$db_pass $db_name < $backup_path"
+            "mysql -u $db_user -h $db_host -P $db_port -p$db_pass $db_name < $backup_path"
         );
         $import->enableOutput();
 

--- a/Lib/Install.php
+++ b/Lib/Install.php
@@ -168,6 +168,9 @@ class Install
             if (isset($options['db-host'])) {
                 $config->database['host'] = $options['db-host'];
             }
+            if (isset($options['db-port'])) {
+                $config->database['port'] = $options['db-port'];
+            }
             if (isset($options['db-name'])) {
                 $config->database['dbname'] = $options['db-name'];
             }
@@ -185,6 +188,7 @@ class Install
                 $keys = [
                     'tables_prefix',
                     'host',
+                    'port',
                     'username',
                     'password',
                     'dbname',

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Supported default environment variables from the official Matomo docker containe
 
 ```bash
 MATOMO_DATABASE_HOST
+MATOMO_DATABASE_PORT
 MATOMO_DATABASE_TABLES_PREFIX
 MATOMO_DATABASE_USERNAME
 MATOMO_DATABASE_PASSWORD
@@ -201,7 +202,7 @@ console matomo:install --install-file=install.json
 #### Example install 2
 ```
 console matomo:install --db-username=myuser --db-pass=password \
-  --db-host=localhost --db-name=matomo --first-site-name=Foo \
+  --db-host=localhost --db-port=3306 --db-name=matomo --first-site-name=Foo \
   --first-site-url=https//foo.bar --first-user='Mr Foo Bar' \
   --first-user-email=foo@bar.com --first-user-pass=secret
 ```
@@ -212,6 +213,7 @@ environment:
       - MATOMO_DB_USERNAME=myuser
       - MATOMO_DB_PASSWORD=secret
       - MATOMO_DB_HOST=mysql
+      - MATOMO_DB_PORT=3306
       - MATOMO_DB_NAME=matomo
       - MATOMO_FIRST_USER_NAME=Mr Foo Bar
       - MATOMO_FIRST_USER_EMAIL=foo@bar.com

--- a/docs/index.md
+++ b/docs/index.md
@@ -201,7 +201,7 @@ console matomo:install --install-file=install.json
 #### Example install 2
 ```
 console matomo:install --db-username=myuser --db-pass=password \
-  --db-host=localhost --db-name=matomo --first-site-name=Foo \
+  --db-host=localhost --db-port=1234 --db-name=matomo --first-site-name=Foo \
   --first-site-url=https//foo.bar --first-user='Mr Foo Bar' \
   --first-user-email=foo@bar.com --first-user-pass=secret
 ```


### PR DESCRIPTION
The `--db-port` argument is not available when using commands like `matomo:install` or `database:create/delete`, preventing to connect any external database in order to bootstrap an installation of the Matomo application.

I believe this can be a good improvement, specially for those databases offered externally, and not just focus on on those deployed internally or defaulting to the `3306` port.