### PR TITLE
added --defaults-extra-file and fixed output error

### DIFF
--- a/Commands/BackupDb.php
+++ b/Commands/BackupDb.php
@@ -56,7 +56,14 @@ You could use options to override config or environment variables:
                 InputOption::VALUE_OPTIONAL,
                 'prefix for backup name',
                 'backup'
-            )
+	    ),
+	    new InputOption(
+		'timeout',
+		't',
+		InputOption::VALUE_OPTIONAL,
+		'timeout for the process',
+		'60'
+	    )
             ]
         );
     }
@@ -67,7 +74,8 @@ You could use options to override config or environment variables:
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $backup_folder = $input->getOption('backup-path');
-        $backup_prefix = $input->getOption('backup-prefix');
+	$backup_prefix = $input->getOption('backup-prefix');
+	$timeout = $input->getOption('timeout');
         // check if we have db backup path in config
         $configs = Config::getInstance();
         $matomo_tools_config = $configs->getFromLocalConfig('ExtraTools');
@@ -92,7 +100,8 @@ You could use options to override config or environment variables:
             'db_pass' => $db_configs['password'],
             'db_name' =>  $db_configs['dbname'],
             'db_backup_folder' => $backup_folder,
-            'db_backup_prefix' => $backup_prefix,
+	    'db_backup_prefix' => $backup_prefix,
+	    'timeout' => $timeout,
         ];
 
         $backup = new Backup($config, $output);

--- a/Lib/Backup.php
+++ b/Lib/Backup.php
@@ -45,7 +45,7 @@ class Backup
         $timestamp = date("Ymd-His");
 
 	$backup = new Process\Process(
-		"mysqldump --defaults-extra-file=$config_path -h $db_host -P $db_port --no-data $db_name --add-drop-table > $backup_folder/$prefix-$timestamp.sql 2> /dev/tty"
+		"mysqldump --defaults-extra-file=$config_path -h $db_host -P $db_port $db_name --add-drop-table > $backup_folder/$prefix-$timestamp.sql 2> /dev/tty"
 	);
 
         $backup->enableOutput();

--- a/Lib/Backup.php
+++ b/Lib/Backup.php
@@ -46,7 +46,6 @@ class Backup
 
 	$backup = new Process\Process(
 		"mysqldump --defaults-extra-file=$config_path -h $db_host -P $db_port --no-data $db_name --add-drop-table > $backup_folder/$prefix-$timestamp.sql 2> /dev/tty"
-		#"mysqldump -u 2$db_user -h$host -P $db_port -p$db_pass --no-data $db_name --add-drop-table > $backup_folder/$prefix-$timestamp.sql 2> /dev/tty"
 	);
 
         $backup->enableOutput();

--- a/Lib/Backup.php
+++ b/Lib/Backup.php
@@ -25,13 +25,14 @@ class Backup
     public function execute()
     {	    
 	// Fetch config.
-        $backup_folder = $this->config['db_backup_folder'];
+	$backup_folder = $this->config['db_backup_folder'];
         $db_host = $this->config['db_host'];
         $db_port = $this->config['db_port'];
         $db_user = $this->config['db_user'];
         $db_pass = $this->config['db_pass'];
         $db_name = $this->config['db_name'];
-        $prefix  = $this->config['db_backup_prefix'];
+	$prefix  = $this->config['db_backup_prefix'];
+	$timeout = $this->config['timeout'];
 	
 	// build temp db config file
 	$temp = tmpfile();
@@ -47,7 +48,7 @@ class Backup
 	$backup = new Process\Process(
 		"mysqldump --defaults-extra-file=$config_path -h $db_host -P $db_port $db_name --add-drop-table > $backup_folder/$prefix-$timestamp.sql 2> /dev/tty"
 	);
-
+	$backup->setTimeout($timeout);
         $backup->enableOutput();
 	$backup->run();
 

--- a/Lib/Backup.php
+++ b/Lib/Backup.php
@@ -38,7 +38,7 @@ class Backup
 	$temp = tmpfile();
 	fwrite($temp,
 		"[client]" . "\n" .
-		"user=1" . $db_user . "\n" .
+		"user=" . $db_user . "\n" .
 		"password=" . $db_pass
 	);
 	$config_path = stream_get_meta_data($temp)['uri'];

--- a/Lib/Backup.php
+++ b/Lib/Backup.php
@@ -38,7 +38,7 @@ class Backup
 	$temp = tmpfile();
 	fwrite($temp,
 		"[client]" . "\n" .
-		"user=" . $db_user . "\n" .
+		"user=1" . $db_user . "\n" .
 		"password=" . $db_pass
 	);
 	$config_path = stream_get_meta_data($temp)['uri'];
@@ -46,7 +46,7 @@ class Backup
         $timestamp = date("Ymd-His");
 
 	$backup = new Process\Process(
-		"mysqldump --defaults-extra-file=$config_path -h $db_host -P $db_port $db_name --add-drop-table > $backup_folder/$prefix-$timestamp.sql 2> /dev/tty"
+		"mysqldump --defaults-extra-file=$config_path -h $db_host -P $db_port $db_name --add-drop-table > $backup_folder/$prefix-$timestamp.sql"
 	);
 	$backup->setTimeout($timeout);
         $backup->enableOutput();


### PR DESCRIPTION
I was having issues with this command on PHP 8.1

- added creation of temp config file to use in --defaults-extra-file so as to not display password in terminal
- fixed error output as I was getting error as in #34 
- added timeout for process