### PR TITLE
Fix deprecated: file_exists() no passing null to parameter

### DIFF
--- a/Commands/InstallMatomo.php
+++ b/Commands/InstallMatomo.php
@@ -267,13 +267,14 @@ Example:
 
     private function fileConfig($file)
     {
-        if (file_exists($file)) {
+        if ($file !== null && file_exists($file)) {
             $config = new stdClass();
             $config->Config = $this->readconf($file);
             return $config;
         }
         return false;
     }
+
     /**
      * Write an output log.
      * @param $text string


### PR DESCRIPTION
Fix deprecation of passing null to non-nullable parameter:

https://php.watch/versions/8.1/internal-func-non-nullable-null-deprecation