### PR TITLE
Prevent duplicates via "site:add"

### DIFF
--- a/Commands/AddSite.php
+++ b/Commands/AddSite.php
@@ -182,6 +182,13 @@ You could use options to override config or environment variables:
 
         $output->writeln("<info>Adding a new site</info>");
         $new = new Site($site);
+
+        if ($new->exists()) {
+            $output->writeln("<comment>Site $siteName already exists</comment>");
+
+            return self::SUCCESS;
+        }
+
         $add_site = $new->add();
         $output->writeln("<comment>Site $siteName added</comment>");
 

--- a/Lib/Site.php
+++ b/Lib/Site.php
@@ -63,6 +63,21 @@ class Site
         return $result;
     }
 
+    public function exists(): bool
+    {
+        $sites = Access::doAsSuperUser(
+            function (): array {
+                $siteName = false;
+                $site = $this->site;
+                extract($site);
+
+                return APISitesManager::getInstance()->getPatternMatchSites($siteName, 1);
+            }
+        );
+
+        return !empty($sites);
+    }
+
     public function list()
     {
         $site_name = [];

--- a/docs/index.md
+++ b/docs/index.md
@@ -155,7 +155,7 @@ List all segments, with ID, definition, date created and latest updated.
 
 ### `site:add`
 
-Adds a new site to track.
+Adds a new site to track. If a site with the same name already exists, no site is added.
 
 ### `site:delete`
 

--- a/templates/docs.twig
+++ b/templates/docs.twig
@@ -102,7 +102,7 @@ docker-compose file, the environment array etc. If the variable is set, Matomo w
 <h3><code>segment:list</code></h3>
 <p>List all segments, with ID, definition, date created and latest updated.</p>
 <h3><code>site:add</code></h3>
-<p>Adds a new site to track.</p>
+<p>Adds a new site to track. If a site with the same name already exists, no site is added.</p>
 <h3><code>site:delete</code></h3>
 <p>Deletes a site with ID provided.</p>
 <h3><code>site:list</code></h3>

--- a/tests/Integration/CommandsTest.php
+++ b/tests/Integration/CommandsTest.php
@@ -72,6 +72,23 @@ class CommandsTest extends ConsoleCommandTestCase
         $this->assertStringContainsStringIgnoringCase("Site Foo added", $this->applicationTester->getDisplay());
     }
 
+    public function testSiteAddWithDuplicateWebsiteNameShouldSkip()
+    {
+        $code = $this->applicationTester->run(array(
+            'command' => 'site:add',
+            '--name' => 'Foo',
+            '-vvv' => true,
+        ));
+        $this->assertEquals(0, $code);
+        $code = $this->applicationTester->run(array(
+            'command' => 'site:add',
+            '--name' => 'Foo',
+            '-vvv' => true,
+        ));
+        $this->assertEquals(0, $code);
+        $this->assertStringContainsStringIgnoringCase("Site Foo already exists", $this->applicationTester->getDisplay());
+    }
+
     public function testSiteListShouldSuceedAndShowUrl()
     {
 


### PR DESCRIPTION
The "site:add" command is now idempotent so it can be called safely for all expected sites.

For simplicity only the site name is checked at the moment. If desired site URLs and the group could be added separately in the future.

Fixes #9