### PR TITLE
Fix DB collation/charset configuration on install

### DIFF
--- a/Lib/Install.php
+++ b/Lib/Install.php
@@ -190,10 +190,10 @@ class Install
             if (isset($options['db-adapter'])) {
                 $config->database['adapter'] = $options['db-adapter'];
             }
-            if (isset($options['collation'])) {
+            if (isset($options['db-collation'])) {
                 $config->database['collation'] = $options['db-collation'];
             }
-            if (isset($options['charset'])) {
+            if (isset($options['db-charset'])) {
                 $config->database['charset'] = $options['db-charset'];
             }
         }


### PR DESCRIPTION
Properly evaluate the DB collation/charset set by environment variables or CLI arguments and store them in the config.ini.php.