### PR TITLE
Make "plugins" CLI option usable on Matomo install

### DIFF
--- a/Lib/Install.php
+++ b/Lib/Install.php
@@ -421,14 +421,14 @@ class Install
         }
         if (isset($fileconfig['PluginsInstalled'])) {
             $installplugins = $fileconfig['PluginsInstalled'];
+        } elseif (isset($option_plugins)) {
+            $installplugins = explode(',', $option_plugins);
         } elseif (isset(($this->config->PluginsInstalled['PluginsInstalled']))) {
             foreach ($this->config->PluginsInstalled['PluginsInstalled'] as $plugin) {
                 if (is_string(($plugin))) {
                     $installplugins[] = $plugin;
                 }
             }
-        } elseif (isset($option_plugins)) {
-            $installplugins = explode(',', $option_plugins);
         }
         if (isset($installplugins)) {
             $install_tag_manager = false;


### PR DESCRIPTION
This actually allows using this option to define the list of plugins to activate. Before the "PluginsInstalled" config option had a higher priority and the CLI option was only used if the config option was empty. And this is impossible: even if not defined in config.ini.php or common.config.ini.php, there is always the list from Matomo's global.ini.php which cannot be cleared.

This is fixed now by processing the CLI option before the config option. Processing of the install file first is left unchanged.

See https://github.com/matomo-org/matomo/blob/0ab4a4b4dae07ddc4d98ac06c703aa0118b22891/config/global.ini.php#L1285